### PR TITLE
reformat logging of allowlist on program start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM --platform=$BUILDPLATFORM golang:1.22.1-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.22.2-alpine3.19 AS build
 WORKDIR /application
 COPY . ./
 ARG TARGETOS

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/wollomatic/socket-proxy
 
-go 1.21
+go 1.22

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/wollomatic/socket-proxy
 
-go 1.22
+go 1.22.2


### PR DESCRIPTION
see https://github.com/wollomatic/socket-proxy/issues/11
Due to the slog package's behaviour, the allowlist-regexes' output is reformatted.

Also add go patch version to go.mod due to CodeQL warning.