### PR TITLE
fix parsing environment variable to configure unix socket

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,10 +120,10 @@ func InitConfig() (*Config, error) {
 	if val, ok := os.LookupEnv("SP_PROXYSOCKETENDPOINT"); ok && val != "" {
 		defaultProxySocketEndpoint = val
 	}
-	if val, ok := os.LookupEnv("SP_PROXYSOCKETENDPOINTALLOWGROUP"); ok {
-		if parsedVal, err := strconv.ParseInt(val, 10, 32); err == nil {
-			defaultProxySocketEndpointFileMode = int(parsedVal)
-		}
+	if val, ok := os.LookupEnv("SP_PROXYSOCKETENDPOINTFILEMODE"); ok {
+		if parsedVal, err := strconv.ParseUint(val, 8, 32); err == nil {
+			defaultProxySocketEndpointFileMode = uint32(parsedVal)
+		}		
 	}
 
 	for i := 0; i < len(mr); i++ {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -123,7 +123,7 @@ func InitConfig() (*Config, error) {
 	if val, ok := os.LookupEnv("SP_PROXYSOCKETENDPOINTFILEMODE"); ok {
 		if parsedVal, err := strconv.ParseUint(val, 8, 32); err == nil {
 			defaultProxySocketEndpointFileMode = uint32(parsedVal)
-		}		
+		}
 	}
 
 	for i := 0; i < len(mr); i++ {


### PR DESCRIPTION
* fix variable name
* use base 8 (unix filemode)
* use 32 bit UINT (unix filemode)

fixes #35 