### PR TITLE
Added expanding environment variables for allow* methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ It is also possible to configure the allowlist via environment variables. The va
 
 If both commandline parameter and environment variable is configured for a particular HTTP method, the environment variable is ignored.
 
-Use Go's regexp syntax to create the patterns for these parameters. To avoid insecure configurations, the characters ^ at the beginning and $ at the end of the string are automatically added. Note: invalid regexp results in program termination.
+Use Go's regexp syntax to create the patterns for these parameters. To avoid insecure configurations, the characters ^ at the beginning and $ at the end of the string are automatically added. Note: invalid regexp results in program termination. It also will be expanded with environment variables.
 
 Examples (command line):
 + `'-allowGET=/v1\..{1,2}/(version|containers/.*|events.*)'` could be used for allowing access to the docker socket for Traefik v2.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,6 +156,11 @@ func InitConfig() (*Config, error) {
 	}
 	flag.Parse()
 
+	for i := range mr {
+		mr[i].regexStringFromParam = os.ExpandEnv(mr[i].regexStringFromParam)
+		mr[i].regexStringFromEnv = os.ExpandEnv(mr[i].regexStringFromEnv)
+	}
+
 	// check listenIP and proxyPort
 	if net.ParseIP(listenIP) == nil {
 		return nil, fmt.Errorf("invalid IP \"%s\" for listenip", listenIP)


### PR DESCRIPTION
Allow to place environment variable into allow* variables content for future expanding when starting to grant permissions for target container only.

Use case(for docker ocmpose): set environments
SP_ALLOW_POST=/v1\\.\\d{1,2}/(exec|containers)/$$CONTAINER_NAME/(start|stop|exec)
CONTAINER_NAME=xxx

More complex example:
```
#cat exts.yaml
services:
  docker-proxy:
    image: wollomatic/socket-proxy:1
    restart: unless-stopped
    read_only: true
    mem_limit: 64M
    hostname: docker_proxy
    security_opt:
      - no-new-privileges
    user: 65534:${DOCKER_GROUP_ID}
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock:ro
    environment:
      - SP_LISTENIP=0.0.0.0
      - SP_LOGLEVEL=INFO
      - SP_PROXYPORT=${DOCKER_PROXY_PORT}
    networks:
      - docker_proxy_net
  docker-proxy-start-stop:
    extends: docker-proxy
    environment:
      - SP_ALLOW_POST=/v1\.\d{1,2}/containers/$$TARGET_CONTAINER/(start|stop)
  docker-proxy-start-stop-exec:
    extends: docker-proxy
    environment:
      - SP_ALLOW_POST=/v1\.\d{1,2}/(exec|containers)/$$TARGET_CONTAINER/(start|stop|exec)
      - SP_ALLOW_GET=/v1\.\d{1,2}/(exec|containers)/.*?/(json)
```

```
#cat compose.yml
services:
  ...
  docker_socket:
    extends:
      file: exts.yml
      service: docker-proxy-start-stop
    environment:
      - SP_ALLOWFROM=my_app_backup
      - TARGET_CONTAINER=my_app
```