### PR TITLE
add bind mount restrictions

### DIFF
--- a/cmd/socket-proxy/bindmount.go
+++ b/cmd/socket-proxy/bindmount.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"path/filepath"
+	"strings"
+)
+
+// mountType is the subset of github.com/docker/docker/api/types/mount.Type.
+type mountType string
+
+const (
+	// mountTypeBind is the type for mounting host dir.
+	mountTypeBind mountType = "bind"
+)
+
+type (
+	// containerCreateRequest is the subset of github.com/docker/docker/api/types/container.CreateRequest.
+	containerCreateRequest struct {
+		HostConfig *containerHostConfig `json:"HostConfig,omitempty"`
+	}
+	// containerHostConfig is the subset of github.com/docker/docker/api/types/container.HostConfig.
+	containerHostConfig struct {
+		Binds  []string     // List of volume bindings for this container.
+		Mounts []mountMount `json:",omitempty"` // Mounts specs used by the container.
+	}
+	// swarmServiceSpec is the subset of github.com/docker/docker/api/types/swarm.ServiceSpec.
+	swarmServiceSpec struct {
+		TaskTemplate swarmTaskSpec `json:",omitempty"`
+	}
+	// swarmTaskSpec is the subset of github.com/docker/docker/api/types/swarm.TaskSpec.
+	swarmTaskSpec struct {
+		ContainerSpec *swarmContainerSpec `json:",omitempty"`
+	}
+	// swarmContainerSpec is the subset of github.com/docker/docker/api/types/swarm.ContainerSpec.
+	swarmContainerSpec struct {
+		Mounts []mountMount `json:",omitempty"`
+	}
+	// mountMount is the subset of github.com/docker/docker/api/types/mount.Mount.
+	mountMount struct {
+		Type mountType `json:",omitempty"`
+		// Source specifies the name of the mount. Depending on mount type, this
+		// may be a volume name or a host path, or even ignored.
+		// Source is not supported for tmpfs (must be an empty value)
+		Source string `json:",omitempty"`
+		Target string `json:",omitempty"`
+	}
+)
+
+// checkBindMountRestrictions checks if bind mounts in the request are allowed.
+func checkBindMountRestrictions(r *http.Request) error {
+	// Only check if bind mount restrictions are configured
+	if len(cfg.AllowBindMountFrom) == 0 {
+		return nil
+	}
+
+	if r.Method != http.MethodPost {
+		return nil
+	}
+
+	// Check different API endpoints that can use bind mounts
+	pathParts := strings.Split(r.URL.Path, "/")
+	switch {
+	case len(pathParts) >= 4 && pathParts[2] == "containers" && pathParts[3] == "create":
+		// Container creation: /vX.xx/containers/create
+		return checkContainer(r)
+	case len(pathParts) >= 5 && pathParts[2] == "containers" && pathParts[4] == "update":
+		// Container update: /vX.xx/containers/{id}/update
+		return checkContainer(r)
+	case len(pathParts) >= 4 && pathParts[2] == "services" && pathParts[3] == "create":
+		// Service creation: /vX.xx/services/create
+		return checkService(r)
+	case len(pathParts) >= 5 && pathParts[2] == "services" && pathParts[4] == "update":
+		// Service update: /vX.xx/services/{id}/update
+		return checkService(r)
+	default:
+		return nil
+	}
+}
+
+// checkContainer checks bind mounts in container creation requests.
+func checkContainer(r *http.Request) error {
+	body, err := readAndRestoreBody(r)
+	if err != nil {
+		return err
+	}
+
+	var req containerCreateRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		slog.Debug("failed to parse container request", "error", err)
+		return nil // Don't block if we can't parse.
+	}
+
+	return checkHostConfigBindMounts(req.HostConfig)
+}
+
+// checkService checks bind mounts in service creation requests.
+func checkService(r *http.Request) error {
+	body, err := readAndRestoreBody(r)
+	if err != nil {
+		return err
+	}
+
+	var req swarmServiceSpec
+	if err := json.Unmarshal(body, &req); err != nil {
+		slog.Debug("failed to parse service request", "error", err)
+		return nil // Don't block if we can't parse.
+	}
+
+	if req.TaskTemplate.ContainerSpec == nil {
+		return nil // No container spec, nothing to check.
+	}
+	return checkHostConfigBindMounts(&containerHostConfig{
+		Mounts: req.TaskTemplate.ContainerSpec.Mounts,
+	})
+}
+
+// checkHostConfigBindMounts checks bind mounts in HostConfig.
+func checkHostConfigBindMounts(hostConfig *containerHostConfig) error {
+	if hostConfig == nil {
+		return nil // No HostConfig, nothing to check
+	}
+
+	// Check legacy Binds field
+	for _, bind := range hostConfig.Binds {
+		if err := validateBindMount(bind); err != nil {
+			return err
+		}
+	}
+
+	// Check modern Mounts field
+	for _, mountItem := range hostConfig.Mounts {
+		if mountItem.Type == mountTypeBind {
+			if err := validateBindMountSource(mountItem.Source); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// validateBindMount validates a bind mount string in the format "source:target:options".
+func validateBindMount(bind string) error {
+	parts := strings.Split(bind, ":")
+	if len(parts) < 2 {
+		return fmt.Errorf("invalid bind mount format: %s", bind)
+	}
+	return validateBindMountSource(parts[0])
+}
+
+// validateBindMountSource checks if the source directory is allowed.
+func validateBindMountSource(source string) error {
+	// Skip if source is not an absolute path (i.e. bind mount).
+	if !strings.HasPrefix(source, "/") {
+		return nil
+	}
+
+	source = filepath.Clean(source) // Clean the path to resolve .. and . components.
+	for _, allowedDir := range cfg.AllowBindMountFrom {
+		if allowedDir == "/" || source == allowedDir || strings.HasPrefix(source, allowedDir+"/") {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("bind mount source directory not allowed: %s", source)
+}
+
+// readAndRestoreBody reads the request body and restores it for further processing.
+func readAndRestoreBody(r *http.Request) ([]byte, error) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read request body: %w", err)
+	}
+
+	// Restore the body for further processing
+	r.Body = io.NopCloser(bytes.NewBuffer(body))
+	return body, nil
+}

--- a/cmd/socket-proxy/bindmount_test.go
+++ b/cmd/socket-proxy/bindmount_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/wollomatic/socket-proxy/internal/config"
+)
+
+func TestValidateBindMountSource(t *testing.T) {
+	cfg = &config.Config{
+		AllowBindMountFrom: []string{"/home", "/var/log"},
+	}
+
+	tests := []struct {
+		name       string
+		source     string
+		shouldPass bool
+	}{
+		{"exact match", "/home", true},
+		{"subdirectory", "/home/user", true},
+		{"deep subdirectory", "/home/user/data", true},
+		{"not allowed", "/etc", false},
+		{"empty source", "", true},      // empty sources are skipped
+		{"relative path", "home", true}, // relative paths are skipped
+		{"var log exact", "/var/log", true},
+		{"var log subdir", "/var/log/app", true},
+		{"similar but different", "/home2", false},
+		{"prefix but not subdir", "/home2/user", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateBindMountSource(tt.source)
+			if tt.shouldPass && err != nil {
+				t.Errorf("expected %s to pass, but got error: %v", tt.source, err)
+			}
+			if !tt.shouldPass && err == nil {
+				t.Errorf("expected %s to fail, but it passed", tt.source)
+			}
+		})
+	}
+}
+
+func TestIsPathAllowed(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		allowedDir string
+		expected   bool
+	}{
+		{"exact match", "/home", "/home", true},
+		{"subdirectory", "/home/user", "/home", true},
+		{"deep subdirectory", "/home/user/data", "/home", true},
+		{"not subdirectory", "/etc", "/home", false},
+		{"similar prefix", "/home2", "/home", false},
+		{"parent directory", "/", "/home", false},
+		{"path traversal with ..", "/home/user/../..", "/home", false},
+		{"path traversal to allowed", "/home/user/..", "/home", true},
+		{"path traversal outside", "/home/../etc", "/home", false},
+		{"complex path traversal", "/home/user/../../etc", "/home", false},
+		{"path with dots in name", "/home/user.name", "/home", true},
+		{"path with current dir", "/home/./user", "/home", true},
+		{"root directory exact match", "/", "/", true},
+		{"any path should be allowed when root is allowed", "/etc", "/", true},
+		{"deep path should be allowed when root is allowed", "/var/log/app", "/", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg = &config.Config{
+				AllowBindMountFrom: []string{tt.allowedDir},
+			}
+			err := validateBindMountSource(tt.path)
+			if (err == nil) != tt.expected {
+				t.Errorf("isPathAllowed(%s, %s) = %v, expected %v", tt.path, tt.allowedDir, err, tt.expected)
+			}
+		})
+	}
+}
+
+func TestValidateBindMount(t *testing.T) {
+	cfg = &config.Config{
+		AllowBindMountFrom: []string{"/home", "/var/log"},
+	}
+
+	tests := []struct {
+		name       string
+		bind       string
+		shouldPass bool
+	}{
+		{"valid bind", "/home/user:/app", true},
+		{"invalid format", "/home/user", false},
+		{"not allowed source", "/etc:/app", false},
+		{"allowed with options", "/home/user:/app:ro", true},
+		{"var log bind", "/var/log:/logs:ro", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateBindMount(tt.bind)
+			if tt.shouldPass && err != nil {
+				t.Errorf("expected %s to pass, but got error: %v", tt.bind, err)
+			}
+			if !tt.shouldPass && err == nil {
+				t.Errorf("expected %s to fail, but it passed", tt.bind)
+			}
+		})
+	}
+}
+
+func TestCheckBindMountRestrictions(t *testing.T) {
+	cfg = &config.Config{
+		AllowBindMountFrom: []string{"/home"},
+	}
+
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		body       string
+		shouldPass bool
+	}{
+		{
+			name:       "GET request should pass",
+			method:     "GET",
+			path:       "/v1.40/containers/json",
+			body:       "",
+			shouldPass: true,
+		},
+		{
+			name:       "POST to non-container endpoint should pass",
+			method:     "POST",
+			path:       "/v1.40/images/create",
+			body:       "",
+			shouldPass: true,
+		},
+		{
+			name:       "container create with allowed bind",
+			method:     "POST",
+			path:       "/v1.40/containers/create",
+			body:       `{"HostConfig":{"Binds":["/home/user:/app"]}}`,
+			shouldPass: true,
+		},
+		{
+			name:       "container create with disallowed bind",
+			method:     "POST",
+			path:       "/v1.40/containers/create",
+			body:       `{"HostConfig":{"Binds":["/etc:/app"]}}`,
+			shouldPass: false,
+		},
+		{
+			name:       "path traversal attack",
+			method:     "POST",
+			path:       "/v1.40/containers/create",
+			body:       `{"HostConfig":{"Binds":["/home/user/../../etc:/app"]}}`,
+			shouldPass: false,
+		},
+		{
+			name:       "container create with no binds",
+			method:     "POST",
+			path:       "/v1.40/containers/create",
+			body:       `{"HostConfig":{}}`,
+			shouldPass: true,
+		},
+		{
+			name:       "container update with bind mount",
+			method:     "POST",
+			path:       "/v1.40/containers/abc123/update",
+			body:       `{"HostConfig":{"Binds":["/home/user:/app"]}}`,
+			shouldPass: true,
+		},
+		{
+			name:       "service create with bind mount",
+			method:     "POST",
+			path:       "/v1.40/services/create",
+			body:       `{"TaskTemplate":{"ContainerSpec":{"Mounts":[{"Type":"bind","Source":"/etc","Target":"/app"}]}}}`,
+			shouldPass: false,
+		},
+		{
+			name:       "v2 API should work too",
+			method:     "POST",
+			path:       "/v2.0/containers/create",
+			body:       `{"HostConfig":{"Binds":["/etc:/app"]}}`,
+			shouldPass: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(tt.method, tt.path, bytes.NewBufferString(tt.body))
+			if err != nil {
+				t.Fatalf("failed to create request: %v", err)
+			}
+
+			err = checkBindMountRestrictions(req)
+			if tt.shouldPass && err != nil {
+				t.Errorf("expected request to pass, but got error: %v", err)
+			}
+			if !tt.shouldPass && err == nil {
+				t.Errorf("expected request to fail, but it passed")
+			}
+		})
+	}
+}

--- a/cmd/socket-proxy/handlehttprequest.go
+++ b/cmd/socket-proxy/handlehttprequest.go
@@ -33,6 +33,12 @@ func handleHTTPRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// check bind mount restrictions
+	if err := checkBindMountRestrictions(r); err != nil {
+		communicateBlockedRequest(w, r, "bind mount restriction: "+err.Error(), http.StatusForbidden)
+		return
+	}
+
 	// finally, log and proxy the request
 	slog.Debug("allowed request", "method", r.Method, "URL", r.URL, "client", r.RemoteAddr)
 	socketProxy.ServeHTTP(w, r) // proxy the request

--- a/cmd/socket-proxy/main.go
+++ b/cmd/socket-proxy/main.go
@@ -58,9 +58,9 @@ func main() {
 	// print configuration
 	slog.Info("starting socket-proxy", "version", version, "os", runtime.GOOS, "arch", runtime.GOARCH, "runtime", runtime.Version(), "URL", programURL)
 	if cfg.ProxySocketEndpoint == "" {
-		slog.Info("configuration info", "socketpath", cfg.SocketPath, "listenaddress", cfg.ListenAddress, "loglevel", cfg.LogLevel, "logjson", cfg.LogJSON, "allowfrom", cfg.AllowFrom, "shutdowngracetime", cfg.ShutdownGraceTime)
+		slog.Info("configuration info", "socketpath", cfg.SocketPath, "listenaddress", cfg.ListenAddress, "loglevel", cfg.LogLevel, "logjson", cfg.LogJSON, "allowfrom", cfg.AllowFrom, "shutdowngracetime", cfg.ShutdownGraceTime, "allowbindmountfrom", cfg.AllowBindMountFrom)
 	} else {
-		slog.Info("configuration info", "socketpath", cfg.SocketPath, "proxysocketendpoint", cfg.ProxySocketEndpoint, "proxysocketendpointfilemode", cfg.ProxySocketEndpointFileMode, "loglevel", cfg.LogLevel, "logjson", cfg.LogJSON, "allowfrom", cfg.AllowFrom, "shutdowngracetime", cfg.ShutdownGraceTime)
+		slog.Info("configuration info", "socketpath", cfg.SocketPath, "proxysocketendpoint", cfg.ProxySocketEndpoint, "proxysocketendpointfilemode", cfg.ProxySocketEndpointFileMode, "loglevel", cfg.LogLevel, "logjson", cfg.LogJSON, "allowfrom", cfg.AllowFrom, "shutdowngracetime", cfg.ShutdownGraceTime, "allowbindmountfrom", cfg.AllowBindMountFrom)
 		slog.Info("proxysocketendpoint is set, so the TCP listener is deactivated")
 	}
 	if cfg.WatchdogInterval > 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -27,6 +28,7 @@ var (
 	defaultStopOnWatchdog              = false                  // set to true to stop the program when the socket gets unavailable (otherwise log only)
 	defaultProxySocketEndpoint         = ""                     // empty string means no socket listener, but regular TCP listener
 	defaultProxySocketEndpointFileMode = uint(0o400)            // set the file mode of the unix socket endpoint
+	defaultAllowBindMountFrom          = ""                     // empty string means no bind mount restrictions
 )
 
 type Config struct {
@@ -42,6 +44,7 @@ type Config struct {
 	SocketPath                  string
 	ProxySocketEndpoint         string
 	ProxySocketEndpointFileMode os.FileMode
+	AllowBindMountFrom          []string
 }
 
 // used for list of allowed requests
@@ -69,12 +72,13 @@ var mr = []methodRegex{
 
 func InitConfig() (*Config, error) {
 	var (
-		cfg              Config
-		allowFromString  string
-		listenIP         string
-		proxyPort        uint
-		logLevel         string
-		endpointFileMode uint
+		cfg                      Config
+		allowFromString          string
+		listenIP                 string
+		proxyPort                uint
+		logLevel                 string
+		endpointFileMode         uint
+		allowBindMountFromString string
 	)
 
 	if val, ok := os.LookupEnv("SP_ALLOWFROM"); ok && val != "" {
@@ -127,6 +131,9 @@ func InitConfig() (*Config, error) {
 			defaultProxySocketEndpointFileMode = uint(parsedVal)
 		}
 	}
+	if val, ok := os.LookupEnv("SP_ALLOWBINDMOUNTFROM"); ok && val != "" {
+		defaultAllowBindMountFrom = val
+	}
 
 	for i := range mr {
 		if val, ok := os.LookupEnv("SP_ALLOW_" + mr[i].method); ok && val != "" {
@@ -152,6 +159,7 @@ func InitConfig() (*Config, error) {
 	}
 	flag.StringVar(&cfg.ProxySocketEndpoint, "proxysocketendpoint", defaultProxySocketEndpoint, "unix socket endpoint (if set, used instead of the TCP listener)")
 	flag.UintVar(&endpointFileMode, "proxysocketendpointfilemode", defaultProxySocketEndpointFileMode, "set the file mode of the unix socket endpoint")
+	flag.StringVar(&allowBindMountFromString, "allowbindmountfrom", defaultAllowBindMountFrom, "allowed directories for bind mounts (comma-separated)")
 	for i := range mr {
 		flag.StringVar(&mr[i].regexStringFromParam, "allow"+mr[i].method, "", "regex for "+mr[i].method+" requests (not set means method is not allowed)")
 	}
@@ -159,6 +167,17 @@ func InitConfig() (*Config, error) {
 
 	// parse comma-separeted allowFromString into allowFrom slice
 	cfg.AllowFrom = strings.Split(allowFromString, ",")
+
+	// parse allowBindMountFromString into AllowBindMountFrom slice and validate
+	if allowBindMountFromString != "" {
+		cfg.AllowBindMountFrom = strings.Split(allowBindMountFromString, ",")
+		for i, dir := range cfg.AllowBindMountFrom {
+			if !strings.HasPrefix(dir, "/") {
+				return nil, fmt.Errorf("bind mount directory must start with /: %q", dir)
+			}
+			cfg.AllowBindMountFrom[i] = filepath.Clean(dir)
+		}
+	}
 
 	// check listenIP and proxyPort
 	if net.ParseIP(listenIP) == nil {


### PR DESCRIPTION
I need this feature to ensure `docker` commands executed by AI agent won't be able to access files outside of current project's directory. This complements rootless docker and together they result in safe AI agent usage.

NB: I've copied data structures from docker API to avoid adding any dependencies to the project.