### PR TITLE
use 0600 as default proxy socket endpoint file mode

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,7 +27,7 @@ var (
 	defaultWatchdogInterval            = uint(0)                // watchdog interval in seconds (0 to disable)
 	defaultStopOnWatchdog              = false                  // set to true to stop the program when the socket gets unavailable (otherwise log only)
 	defaultProxySocketEndpoint         = ""                     // empty string means no socket listener, but regular TCP listener
-	defaultProxySocketEndpointFileMode = uint(0o400)            // set the file mode of the unix socket endpoint
+	defaultProxySocketEndpointFileMode = uint(0o600)            // set the file mode of the unix socket endpoint
 	defaultAllowBindMountFrom          = ""                     // empty string means no bind mount restrictions
 )
 


### PR DESCRIPTION
The README documents that the default value for the proxy socket endpoint file mode parameter/environment variable is `0600`, but the code actually has it as `0400`. I could not get the unix socket to work with my Beszel agents with the default (no error message, yet no data retrieved), but when I checked the newly added wiki example, I saw that it explicitly set this parameter to `0600`. Copying this allowed my setup to work, so I'm proposing that the actual default value be changed to `0600` to match the README.