### PR TITLE
pin gosec to v2.23.0 version - try to fix weird behaviour

### DIFF
--- a/.github/workflows/docker-image-release.yaml
+++ b/.github/workflows/docker-image-release.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@398ad549bbf1a51dc978fd966169f660c59774de # v2.23.0
+        uses: securego/gosec@v2.23.0
         with:
           args: ./...
 

--- a/.github/workflows/docker-image-testing.yaml
+++ b/.github/workflows/docker-image-testing.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@398ad549bbf1a51dc978fd966169f660c59774de # v2.23.0
+        uses: securego/gosec@v2.23.0
         with:
           args: ./...
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration security scanning actions to reference semantic version tags instead of commit hashes across deployment and testing pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->