### PR TITLE
update to Go 1.26.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.23@sha256:18b460dd17542c2ba43299a633cf6ebfc1115101509531471d7cfce1019af083 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.24@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS build
 WORKDIR /application
 COPY . ./
 ARG TARGETOS

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # socket-proxy
 
 ## Latest image
-- `wollomatic/socket-proxy:1.12.2` / `ghcr.io/wollomatic/socket-proxy:1.12.2`
+- `wollomatic/socket-proxy:1.12.3` / `ghcr.io/wollomatic/socket-proxy:1.12.3`
 - `wollomatic/socket-proxy:1` / `ghcr.io/wollomatic/socket-proxy:1`
 
 > [!IMPORTANT]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment to use a newer Go and Alpine Linux base image.
* **Documentation**
  * Updated the README’s latest Docker image references to version 1.12.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->