### PR TITLE
Stop pushing generic test images to Docker Hub and use unique test im…

### DIFF
--- a/.github/workflows/docker-image-testing.yaml
+++ b/.github/workflows/docker-image-testing.yaml
@@ -42,12 +42,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
@@ -55,7 +49,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push image to Docker Hub and GHCR
+      - name: Build and push image to GHCR
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         id: push-all
         with:
@@ -64,9 +58,6 @@ jobs:
           push: true
           build-args: VERSION=testing-${{ github.sha }}
           tags: |
-            docker.io/wollomatic/socket-proxy:testing
-            docker.io/wollomatic/socket-proxy:testing-${{ github.sha }}
-            ghcr.io/wollomatic/socket-proxy:testing
             ghcr.io/wollomatic/socket-proxy:testing-${{ github.sha }}
 
 #      - name: Build and push Docker Hub image


### PR DESCRIPTION
…age tags only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Container images are now published exclusively to GitHub Container Registry.
  * Removed Docker Hub publishing and related image tags from the testing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->