### PR TITLE
Update to Go 1.26.6, prepare v1.13.1

### DIFF
--- a/.github/workflows/docker-image-release.yaml
+++ b/.github/workflows/docker-image-release.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Run Gosec Security Scanner
         run: |
-          go install github.com/securego/gosec/v2/cmd/gosec@v2.23.0
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
           gosec ./...
 
       - name: Run Go tests

--- a/.github/workflows/docker-image-release.yaml
+++ b/.github/workflows/docker-image-release.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26'
+          go-version: '1.26.6'
 
       - name: Run Gosec Security Scanner
         run: |

--- a/.github/workflows/docker-image-testing.yaml
+++ b/.github/workflows/docker-image-testing.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run Gosec Security Scanner
         run: |
-          go install github.com/securego/gosec/v2/cmd/gosec@v2.23.0
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
           gosec ./...
 
       - name: Run Go tests

--- a/.github/workflows/docker-image-testing.yaml
+++ b/.github/workflows/docker-image-testing.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26'
+          go-version: '1.26.6'
 
       - name: Run Gosec Security Scanner
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.24@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine3.24@sha256:af8d6740070b8906d12eae1c3e3ea0957fb63f492051ea05e354c38ef9fe88df AS build
 WORKDIR /application
 COPY . ./
 ARG TARGETOS

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # socket-proxy
 
 ## Latest image
-- `wollomatic/socket-proxy:1.13.0` / `ghcr.io/wollomatic/socket-proxy:1.13.0`
+- `wollomatic/socket-proxy:1.13.1` / `ghcr.io/wollomatic/socket-proxy:1.13.1`
 - `wollomatic/socket-proxy:1` / `ghcr.io/wollomatic/socket-proxy:1`
 
 > [!IMPORTANT]

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/wollomatic/socket-proxy
 
-go 1.26.0
+go 1.26.6


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the build environment and Go version to 1.26.6.
  * Refreshed container image references to version 1.13.1 in the documentation.
  * Updated the security scanning tool used during builds and releases to version 2.28.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->